### PR TITLE
add template hpa

### DIFF
--- a/charts/basic-app/templates/hpa.yaml
+++ b/charts/basic-app/templates/hpa.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.autoscaling.enabled -}}
+apiVersion: {{ ternary "autoscaling/v2" "autoscaling/v1" (.Capabilities.APIVersions.Has "autoscaling/v2") }}
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "basic-deployment.name" . }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "basic-deployment.name" . }}
+  minReplicas: {{ .Values.replicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.cpu }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.cpu }}
+    {{- end }}
+    {{- if .Values.autoscaling.memory }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageValue: {{ .Values.autoscaling.memory }}
+    {{- end }}
+{{- end }}

--- a/charts/basic-app/templates/hpa.yaml
+++ b/charts/basic-app/templates/hpa.yaml
@@ -12,9 +12,7 @@ spec:
     name: {{ include "basic-deployment.name" . }}
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
-  {{ if and ( eq .Capabilities.KubeVersion.Major "1") ( lt .Capabilities.KubeVersion.Minor "23") }}
-  targetCPUUtilizationPercentage: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
-  {{- else }}
+  {{ if .Capabilities.APIVersions.Has "autoscaling/v2" }}
   metrics:
   {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
   - type: Resource
@@ -32,5 +30,7 @@ spec:
         type: Utilization
         averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
   {{- end }}
+  {{- else }}
+  targetCPUUtilizationPercentage: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
   {{- end }}
 {{- end }}

--- a/charts/basic-app/templates/hpa.yaml
+++ b/charts/basic-app/templates/hpa.yaml
@@ -3,6 +3,8 @@ apiVersion: {{ ternary "autoscaling/v2" "autoscaling/v1" (.Capabilities.APIVersi
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "basic-deployment.name" . }}
+  labels:
+    {{- include "basic-deployment.labels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
@@ -10,7 +12,7 @@ spec:
     name: {{ include "basic-deployment.name" . }}
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
-  {{- if not (.Capabilities.APIVersions.Has "autoscaling/v2") }}
+  {{ if and ( eq .Capabilities.KubeVersion.Major "1") ( lt .Capabilities.KubeVersion.Minor "23") }}
   targetCPUUtilizationPercentage: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
   {{- else }}
   metrics:

--- a/charts/basic-app/templates/hpa.yaml
+++ b/charts/basic-app/templates/hpa.yaml
@@ -30,7 +30,5 @@ spec:
         type: Utilization
         averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
   {{- end }}
-  behavior:
   {{- end }}
-
 {{- end }}

--- a/charts/basic-app/templates/hpa.yaml
+++ b/charts/basic-app/templates/hpa.yaml
@@ -8,19 +8,29 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: {{ include "basic-deployment.name" . }}
-  minReplicas: {{ .Values.replicas }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  {{- if not (.Capabilities.APIVersions.Has "autoscaling/v2") }}
+  targetCPUUtilizationPercentage: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+  {{- else }}
   metrics:
-    {{- if .Values.autoscaling.cpu }}
-    - type: Resource
-      resource:
-        name: cpu
-        targetAverageUtilization: {{ .Values.autoscaling.cpu }}
-    {{- end }}
-    {{- if .Values.autoscaling.memory }}
-    - type: Resource
-      resource:
-        name: memory
-        targetAverageValue: {{ .Values.autoscaling.memory }}
-    {{- end }}
+  {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+  {{- end }}
+  {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+  {{- end }}
+  behavior:
+  {{- end }}
+
 {{- end }}


### PR DESCRIPTION
Adicionei a linha 2 e removi o que não era necessário.
Fiz teste no kind usando versões 1.22.17, 1.23.17 e 1.24.7 
Versões 1.22 e 1.23 peragram o autoscaling/v1
A versão 1.24 pegou o autoscaling/v2 